### PR TITLE
Add custom token for push to protected master branch

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOVERSION_TOKEN }}
           EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_COMMITTER_NAME: github-actions[bot]


### PR DESCRIPTION
Add custom token for push to protected master branch. The default
secretes.GITHUB_TOKEN does not seem to have admin privileges so short
of setting up a custom GitHub app, I will create a Personal Access
Token (Pat) to write to the master branch.