### PR TITLE
Disable cron auto-version action

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -1,14 +1,11 @@
 on:
-  schedule:
-    - cron: "30 2 * * *"
+  # schedule:
+  #   - cron: "30 2 * * *"
   workflow_dispatch:
 jobs:
   auto-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: de-vri-es/setup-git-credentials@v2
-        with:
-          credentials: ${{secrets.AUTOVERSION_TOKEN}}
       - uses: actions/checkout@v2
       - env:
           GITHUB_TOKEN: ${{ secrets.AUTOVERSION_TOKEN }}


### PR DESCRIPTION
Disable cron auto-version action as it is still failing. It seems we
might need a GitHub App with correct credentials to get it to work.

Remove git-credentials action as we couldn't get it to work with branch
protection.