### PR TITLE
manifest: Add howl.hcl

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -1,6 +1,6 @@
 on:
-  # schedule:
-  #   - cron: "30 2 * * *"
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 jobs:
   auto-version:

--- a/howl.hcl
+++ b/howl.hcl
@@ -1,0 +1,10 @@
+description = "howl sends slack or dsicord messages on github build failures"
+source = "https://github.com/foxygoat/howl/releases/download/v${version}/howl"
+binaries = ["howl"]
+requires = ["jq", "gh"]
+
+version "2.0.2" {
+  auto-version {
+    github-release = "foxygoat/howl"
+  }
+}


### PR DESCRIPTION
Add howl.hcl so that we can install `howl` with hermit.

While at it, re-instate the corn job (we aren't running it that often).